### PR TITLE
Fix for inline configuration values error

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports.auth = function(params) {
   }
 
   if(!params.strategy) {
-    params.strategy = openid();
+    params.strategy = openid(params);
   }
 
   return async (req, res, next) => {


### PR DESCRIPTION
Fixes #8 

Simply passes inline configuration values into the openid strategy constructor to ensure inline values are used to create the strategy.
