### PR TITLE
Update ReadMe with Import Statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ ALLOWED_AUDIENCES=https://api.yourapplication.com
 ... or in your application code:
 
 ```js
+const { auth } = require('express-oauth2-bearer');
+
 app.use(auth({
   issuerBaseURL: 'https://tenant.auth0.com',
   allowedAudiences: 'https://api.yourapplication.com'


### PR DESCRIPTION
Since we are showing how to configure the SDK for the first time, we should also include where to import `auth` from.
