### PR TITLE
chore: add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/auth0/express-oauth2-bearer.git"
+    "url": "https://github.com/auth0/express-oauth2-bearer.git"
   },
   "dependencies": {
     "http-errors": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   },
   "author": "Auth0 <support@auth0.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/auth0/express-oauth2-bearer.git"
+  },
   "dependencies": {
     "http-errors": "^1.7.3",
     "jose": "^1.18.1",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

By adding the repository to the package.json it allows the use of
the command `npm repo express-oauth0-bearer` to resolve to
the correct repository.

### References

- `node-cache`: https://github.com/node-cache/node-cache/blob/master/package.json#L45-L48
- `express`: https://github.com/expressjs/express/blob/master/package.json#L16

### Testing
- It's not possible to test that this change has an effect until this package is published into the npmjs public registry.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
